### PR TITLE
Fix event firing on anichart.net

### DIFF
--- a/anilist-chinese.user.template.js
+++ b/anilist-chinese.user.template.js
@@ -87,7 +87,7 @@ var myDOMNodeInsertedAction = function () {
   }, 200);
 };
 var observer = new MutationObserver(myDOMNodeInsertedAction);
-observer.observe(document.getElementById("app"), {
+observer.observe(document.body, {
   childList: true,
   subtree: true,
 });


### PR DESCRIPTION
The `<div id=app></div>` placeholder would be removed and then recreated on anichart.net, so listen on the document body instead.